### PR TITLE
Explicitly use lifecycle viewmodel dep to fix duplicate build error

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,19 +5,19 @@
 ext.deps = [:]
 def versions = [:]
     versions.composeVersion = "1.1.1"
-    versions.composeCompilerVersion = "1.2.0-dev-k1.6.21-56a408a3809"
-    versions.appCompatVersion = "1.4.0"
+    versions.composeCompilerVersion = "1.2.0"
+    versions.appCompatVersion = "1.5.0"
     versions.coroutinesVersion = "1.6.4"
     versions.espressoVersion = "3.4.0"
     versions.gradleVersion = "7.2.0"
     versions.hiltAndroidXVersion = "1.0.0"
     versions.hiltVersion = "2.43"
-    versions.kotlinVersion = "1.6.21"
+    versions.kotlinVersion = "1.7.0"
     versions.ktxVersion = "1.7.0"
-    versions.lifecycleVersion = "2.4.1"
+    versions.lifecycleVersion = "2.5.0"
     versions.materialVersion = "1.4.0"
-    versions.navigationVersion = "2.4.1"
-    versions.roomVersion = "2.4.2"
+    versions.navigationVersion = "2.5.0"
+    versions.roomVersion = "2.5.0-alpha02"
     versions.testExtJunitVersion = "1.1.3"
     versions.retrofitVersion = "2.9.0"
     versions.moshiVersion = "1.13.0"
@@ -34,8 +34,8 @@ ext.versions = versions
 
 def buildVersions = [:]
     buildVersions.minSdkVersion = 23
-    buildVersions.compileSdkVersion = 31
-    buildVersions.targetSdkVersion = 31
+    buildVersions.compileSdkVersion = 32
+    buildVersions.targetSdkVersion = 32
 ext.buildVersions = buildVersions
 
 def deps = [:]


### PR DESCRIPTION
- This error was encountered when upgrading to the latest hilt version:
Duplicate class androidx.lifecycle.ViewModelLazy found in modules lifecycle-viewmodel-2.5.0-runtime (androidx.lifecycle:lifecycle-viewmodel:2.5.0) and lifecycle-viewmodel-ktx-2.3.1-runtime (androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1)
- Apparently some modules are requesting to use version 2.5.0 of
  lifecycle-viewmodel (this was found out after using ./gradlew
:app:dependencies)
- Further digging found out that androidx.activity had to upgraded to
  1.5.0, lifecycle to 1.5.0 to fix this
- Upgrading to kotlin 1.7.0 brought its own set of errors--room version
  2.4. isn't compatible with it (DELETE query methods must either return
    void or int (the number of deleted rows) kotlin version 1.7.0) and had to use alpha version, I also had to increase target SDK level to 32
- see https://issuetracker.google.com/issues/236612358 for reference
Signed-off-by: Alvin Dizon <alvin.dizon91@gmail.com>