### PR TITLE
Create data class so repeated messages can be shown via Snackbar

### DIFF
--- a/common/design/src/main/java/com/alvindizon/panahon/design/message/UiMessage.kt
+++ b/common/design/src/main/java/com/alvindizon/panahon/design/message/UiMessage.kt
@@ -1,0 +1,8 @@
+package com.alvindizon.panahon.design.message
+
+import java.util.*
+
+data class UiMessage(
+    val message: String,
+    val id: Long = UUID.randomUUID().mostSignificantBits,
+)

--- a/feature/details/src/main/java/com/alvindizon/panahon/details/ui/DetailsUi.kt
+++ b/feature/details/src/main/java/com/alvindizon/panahon/details/ui/DetailsUi.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.alvindizon.panahon.design.components.DataUnavailableScreen
-import com.alvindizon.panahon.design.components.NoDataScreen
 import com.alvindizon.panahon.design.theme.Hot
 import com.alvindizon.panahon.design.theme.PanahonTheme
 import com.alvindizon.panahon.design.theme.Snow
@@ -51,9 +50,9 @@ fun DetailsScreen(
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
     val state = viewModel.uiState.collectAsState().value
-    state.errorMessage?.let {
-        LaunchedEffect(it) {
-            snackbarHostState.showSnackbar(it)
+    state.errorMessage?.let { message ->
+        LaunchedEffect(message) {
+            snackbarHostState.showSnackbar(message.message)
         }
     }
     Scaffold(
@@ -109,9 +108,7 @@ internal fun DetailedForecastScreen(
             .pullRefresh(refreshState)
             .fillMaxSize() // fillMaxSize so that pull refresh indicator won't be aligned at top start
     ) {
-        if (state.detailedForecast == null) {
-            NoDataScreen()
-        } else {
+        if (state.detailedForecast != null) {
             DetailedForecastScreen(
                 modifier = Modifier.padding(paddingValues),
                 detailedForecast = state.detailedForecast

--- a/feature/details/src/main/java/com/alvindizon/panahon/details/viewmodel/DetailsScreenViewModel.kt
+++ b/feature/details/src/main/java/com/alvindizon/panahon/details/viewmodel/DetailsScreenViewModel.kt
@@ -3,6 +3,7 @@ package com.alvindizon.panahon.details.viewmodel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.alvindizon.panahon.design.message.UiMessage
 import com.alvindizon.panahon.details.model.DetailedForecast
 import com.alvindizon.panahon.details.navigation.DetailsNavigation
 import com.alvindizon.panahon.details.usecase.FetchDetailedForecastUseCase
@@ -18,7 +19,7 @@ import javax.inject.Inject
 data class DetailsScreenUiState(
     val detailedForecast: DetailedForecast? = null,
     val isLoading: Boolean = true,
-    val errorMessage: String? = null
+    val errorMessage: UiMessage? = null
 )
 
 @HiltViewModel
@@ -67,7 +68,7 @@ class DetailsScreenViewModel @Inject constructor(
     private fun handleError(error: Throwable) {
         _uiState.value = _uiState.value.copy(
             isLoading = false,
-            errorMessage = error.message ?: error.javaClass.name
+            errorMessage = UiMessage(error.message ?: error.javaClass.name)
         )
     }
 }

--- a/feature/details/src/test/java/com/alvindizon/panahon/details/viewmodel/DetailsScreenViewModelTest.kt
+++ b/feature/details/src/test/java/com/alvindizon/panahon/details/viewmodel/DetailsScreenViewModelTest.kt
@@ -44,7 +44,7 @@ class DetailsScreenViewModelTest {
             // seems like you only need coEvery for suspending functions--if you use coEvery here
             // you won't get an error
             every { fetchDetailedForecastUseCase(any(), any(), any()) } throws Throwable("bleh")
-            assertEquals("bleh", viewModel.uiState.value.errorMessage)
+            assertEquals("bleh", viewModel.uiState.value.errorMessage?.message)
         }
 
 


### PR DESCRIPTION
- previously, when the device has no connectivity, a snackbar will be initially shown on refresh, but subsequent refreshes will not result in a snackbar being shown.
- This is because the error message does not change ("No internet connection"), and thus, LaunchedEffect will not run again.
- To ensure that LaunchedEffect will always run for the same String, a wrapper data class called UiMessage that contains the String and a random value is created, and it is used as the key for LaunchedEffect instead of the String message itself.
- See https://github.com/chrisbanes/tivi/blob/main/common/ui/view/src/main/java/app/tivi/api/UiMessage.kt and https://stackoverflow.com/questions/71887759/compose-snackbar-not-appearing-on-repeated-error

Signed-off-by: Alvin Dizon <alvin.dizon91@gmail.com>